### PR TITLE
Add Travis CI to do flake8 testing on each commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: python
+cache: pip
+python:
+    - 2.7.13
+    - 3.6
+install:
+    - pip install flake8
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - time flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - time flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+    - true  # <-- add other tests here...
+notifications:
+    on_success: change
+    on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
Each time someone adds code to this repo, CI automatically can run tests on it.  The owner of the this repo would need to go to https://travis-ci.org/profile and __flip the repository switch on__ to enable free automated flake8 testing on each pull request.